### PR TITLE
Add translations, move some things around

### DIFF
--- a/src/help.html
+++ b/src/help.html
@@ -13,7 +13,10 @@
 
 <ul>
   <li><a href="#SageStandardDoc">Sage standard documentation</a></li>
-  <li><a href="./doc-html/">Translations of the standard documentation</a></li>
+  <ul>
+    <li><a href="./doc-html/">Some translations of the standard documentation</a>;
+      see also <a href="#moretranslations">here</a>.</li>
+  </ul>
   <li><a href="#furtherResources">Further resources</a></li>
   <li><a href="./development.html#mailingList">Support and discussion groups</a></li>
   <li><a href="./help-uSage.html">uSage User Groups</a></li>
@@ -25,7 +28,8 @@
 <div class="normal justify bodypadding">
 The 
 <a href="./doc/index.html">Sage standard documentation</a> consists of the following documents, in both
-HTML and PDF versions. (<a href="./doc-html/">Translations of the standard documentation</a>)
+  HTML and PDF versions. 
+  <br />(<a href="./doc-html/">Some translations of the standard documentation</a>)
 <br>
 
 {#
@@ -45,9 +49,17 @@ HTML and PDF versions. (<a href="./doc-html/">Translations of the standard docum
   <ul>
     <li><a href="./doc-html/fr/a_tour_of_sage/">Sage en quelques mots (Français)</a>,
       <a href="./pdf/fr/a_tour_of_sage/a_tour_of_sage.pdf">PDF</a></li>
+    <li><a href="./doc-html/de/a_tour_of_sage/">Ein Rundgang durch Sage (Deutsch)</a>,
+      <a href="./pdf/de/a_tour_of_sage/a_tour_of_sage.pdf">PDF</a></li>
+    <li><a href="./doc-html/it/a_tour_of_sage/">Esplora Sage (Italiano)</a>,
+      <a href="./pdf/it/a_tour_of_sage/a_tour_of_sage.pdf">PDF</a></li>
+    <li><a href="./doc-html/pt/a_tour_of_sage/">Uma Turnê pelo Sage (Português)</a>,
+      <a href="./pdf/pt/a_tour_of_sage/a_tour_of_sage.pdf">PDF</a></li>
+    <li><a href="./doc-html/tr/a_tour_of_sage/">Sage Turu (Türk dili)</a>,
+      <a href="./pdf/tr/a_tour_of_sage/a_tour_of_sage.pdf">PDF</a></li>
   </ul>
 
-  <li><a href="./doc/tutorial/">Tutorial</a>
+  <li>Official <a href="./doc/tutorial/">Tutorial</a>
     (<a href="http://www.amazon.com/Sage-tutorial-version-3-4-Group/dp/1442141948/ref=sr_1_2?ie=UTF8&amp;s=books&amp;qid=1261010025&amp;sr=1-2">Printed &amp; Bound</a>),
     <a href="./pdf/en/tutorial/SageTutorial.pdf">PDF</a>
     &mdash; information for beginners, recommended
@@ -55,25 +67,15 @@ HTML and PDF versions. (<a href="./doc-html/">Translations of the standard docum
       <li><a href="./doc-html/de/tutorial/">Sage Tutorial (Deutsch)</a>,
 	<a href="./pdf/de/tutorial/SageTutorial-de.pdf">PDF</a></li>
 
-      <li><a href="./doc-html/de/thematische_anleitungen/index.html">Sage thematische Anleitungen (Deutsch)</a>,
-        <a href="./pdf/de/thematische_anleitungen/ThematischeAnleitungen-de.pdf">PDF</a></li>
-
-      <li><a href="./es/Manual_SAGE_principiantes.pdf">Manual de Sage
-	  para principiantes (Español)</a></li>
-
-      <li><a href="./es/Introduccion_a_SAGE.pdf">Introduccion:
-	  Matemáticas Elementales con Sage (Español)</a></li>
-
       <li><a href="./doc-html/fr/tutorial/">Tutoriel Sage (Français)</a>,
 	<a href="./pdf/fr/tutorial/tutorial-fr.pdf">PDF</a></li>
 
       <li><a href="./doc-html/ru/tutorial/">учебное пособие Sage (русский язык)</a>,
 	<a href="./pdf/ru/tutorial/SageTutorial_ru.pdf">PDF</a></li>
 
-<li><a href="./files/Sage_Persian_tutorial.pdf">Persian Tutorial (Farsi): آموزش فارسی (PDF)</a> (<a href="./files/Sage_Persian_tutorial.docx">DOCX</a>)</li>
     </ul>
   </li>
-
+  
   <li><a href="./doc/thematic_tutorials/">Thematic Tutorials</a>,
     <a href="./pdf/en/thematic_tutorials/thematic_tutorials.pdf">PDF</a>
     <ul>
@@ -83,6 +85,8 @@ HTML and PDF versions. (<a href="./doc-html/">Translations of the standard docum
 	<li><a href="./doc/prep/Intro-Tutorial.html">Introductory Sage Tutorial (PREP)</a></li>
 	<li><a href="./doc/thematic_tutorials/tutorial-notebook-and-help-long.html">Tutorial: Using the Sage notebook, navigating the help system, first exercises</a></li>
 	<li><a href="./doc/tutorial/">Sage’s main tutorial</a></li>
+        <li><a href="./doc-html/de/thematische_anleitungen/sage_gymnasium.html">Sage thematische Anleitungen (Deutsch)</a>,
+        <a href="./pdf/de/thematische_anleitungen/sage_gymnasium.pdf">PDF</a></li>
       </ul>
 
       <li>Calculus and plotting</li>
@@ -209,76 +213,102 @@ HTML and PDF versions. (<a href="./doc-html/">Translations of the standard docum
 <!-- further resources -->
 <h2><a name="furtherResources">Further resources</a></h2>
   <ul>
-    <li><a href="http://wiki.sagemath.org/quickref">Quick Reference Cards</a> &mdash;
-        overview of  important functions</li>
+     <li id="moretranslations">More Translated Resources</li>
+       <ul>
+        <li><a href="./es/Introduccion_a_SAGE.pdf">Introduccion:
+          Matemáticas Elementales con Sage (Español)</a></li>
+        <li><a href="./es/Manual_SAGE_principiantes.pdf">Manual de Sage
+	  para principiantes (Español)</a></li>
+        <li><a href="./files/Sage_Persian_tutorial.pdf">Persian Tutorial (Farsi): آموزش فارسی (PDF)</a> 
+          <a href="./files/Sage_Persian_tutorial.docx">DOCX</a>)</li>
+        <li><a href="./files/introduccio-al-sage_Amoros2012.pdf">Introducci&#243; al SAGE</a>
+          &mdash; mini tutorial in Catalan by Maria Bras Amor&#243;s</li>
+     </ul>
+  </ul>
 
-    <li><a href="./help-irc.html">IRC help channel</a> &mdash;
-          directly connects you to an online chat room</li>
-
-    <li><a href="./help-video.html"><strong>Screencasts</strong></a> &mdash;
-      videos explaining how Sage works</li>
-
-    <li><b><a href="http://www.gregorybard.com/SAGE.html">Gregory V. Bard - Sage for Undergraduates</a> (<a href="http://www.gregorybard.com/sage_for_undergraduates_color.pdf.zip">PDF</a>)</b> &mdash;
-     detailed introduction into Sage for undergraduates and others, who simply want to learn Sage.
-     Published by "The American Mathematical Society", 2014.</b></li>
-
-    <li><a href="http://arachnoid.com/sage/">
-        Exploring Mathematics with Sage</a> by Paul Lutus &mdash; overview
-      of using Sage in various areas of applied mathematics</li>
-
-    <li><a href="http://www-rohan.sdsu.edu/~mosulliv/Teaching/sdsu-sage-tutorial/index.html">Sage Tutorial</a> by Mike O'Sullivan, Ryan Rosenbaum, and  David Monarres</li>
-
-    <li><a href="./files/introduccio-al-sage_Amoros2012.pdf">Introducci&#243; al SAGE</a> &mdash; mini tutorial in Catalan by Maria Bras Amor&#243;s</li>
-
-    <li><a href="http://sage.math.washington.edu/home/tkosan/newbies_book/"
-          >Sage for Newbies</a> &mdash; book by T. Kosan</li>
-
-    <li><a href="http://wiki.sagemath.org/faq"
+  <ul>
+     <li>More Sage-hosted resources</li>
+       <ul>
+        <li><a href="http://wiki.sagemath.org/quickref">Quick Reference Cards</a> &mdash;
+          overview of  important functions</li>
+        <li><a href="./help-irc.html">IRC help channel</a> &mdash;
+            directly connects you to an online chat room</li>
+        <li><a href="./help-video.html"><strong>Screencasts</strong></a> &mdash;
+          videos explaining how Sage works</li>
+        <li><a href="http://wiki.sagemath.org/faq"
           >FAQ: Frequently Asked Questions</a></li>
-
-    <li><a href="./library-publications.html#books">Books</a> &mdash; a collection of
-      online books explaining mathematics (calculus, linear algebra,
-      number theory, etc.) using Sage</li>
-
-    <li><a href="http://openwetware.org/wiki/Open_writing_projects/Sage_and_cython_a_brief_introduction"
-          >Sage and Cython: A Brief Introduction</a>
-      by Marshall Hampton &mdash; a brief introduction to Sage focusing on
-      Cython</li>
-
-    <li><a href="http://bitbucket.org/mvngu/numtheory-crypto/downloads/numtheory-crypto.pdf"
-          >Number Theory and the RSA Public Key Cryptosystem</a>
-      by Minh Van Nguyen &mdash; using Sage to study elementary number
-      theory and the RSA public key cryptosystem</li>
-
-    <li><a href="http://www.steinertriples.fr/ncohen/tut/LP/"
-          >Linear Programming in Sage</a> by Nathann Cohen
-      &mdash; There are many very good solvers around and they are now
-      available in Sage.</li>
-
-    <li><a href="http://www.steinertriples.fr/ncohen/tut/Graphs/"
-          >Sage and Graph Theory</a> by Nathann Cohen
-      &mdash; Sage will not solve your graph problems in polynomial time.
-      But everything that is already written, YOU do not have to write it
-      again!</li>
-
-    <li><a href="http://sage.math.washington.edu/home/wdj/cookbook/coding-theory/sage-coding-cookbook.pdf"
-          >Linear Error-Correcting Codes</a> by David Joyner and
-      Robert Miller &mdash; introduces some of Sage's functionality in the
-      theory of error-correcting codes</li>
-
-    <li><a href="http://buzzard.ups.edu/sage/sage-group-theory-primer.pdf"
-          >Group Theory and Sage: A Primer</a> by Rob Beezer
-      &mdash; a compilation of Sage commands useful for a student studying
-      group theory for the first time</li>
-
-    <li><a href="http://planet.sagemath.org/"
+        <li><a href="./library-publications.html#books">Books</a> &mdash; a collection of
+          online books explaining mathematics (calculus, linear algebra,
+          number theory, etc.) using Sage</li>
+        <li><a href="http://planet.sagemath.org/"
           >Planet Sage Blogs</a> &mdash; a collection of blogs by
-      Sage users and developers</li>
+          Sage users and developers</li>
+        <li><a href="./search.html"><strong>Search</strong></a> &mdash; an
+          online search interface indexing Sage documentation, discussion
+          groups, various web resources, blogs and various other places on
+          the web</li>
+     </ul>
+  </ul>
 
-    <li><a href="./search.html"><strong>Search</strong></a> &mdash; an
-      online search interface indexing Sage documentation, discussion
-      groups, various web resources, blogs and various other places on
-      the web</li>
+  <ul>
+     <li>Contributed Thematic Tutorials</li>
+       <ul>
+        <li><a href="http://openwetware.org/wiki/Open_writing_projects/Sage_and_cython_a_brief_introduction"
+          >Sage and Cython: A Brief Introduction</a>
+          by Marshall Hampton &mdash; a brief introduction to Sage focusing on
+          Cython</li>
+
+        <li><a href="http://bitbucket.org/mvngu/numtheory-crypto/downloads/numtheory-crypto.pdf"
+          >Number Theory and the RSA Public Key Cryptosystem</a>
+          by Minh Van Nguyen &mdash; using Sage to study elementary number
+          theory and the RSA public key cryptosystem</li>
+
+        <li><a href="http://www.steinertriples.fr/ncohen/tut/LP/"
+          >Linear Programming in Sage</a> by Nathann Cohen
+          &mdash; There are many very good solvers around and they are now
+          available in Sage.</li>
+
+        <li><a href="http://www.steinertriples.fr/ncohen/tut/Graphs/"
+          >Sage and Graph Theory</a> by Nathann Cohen
+          &mdash; Sage will not solve your graph problems in polynomial time.
+          But everything that is already written, YOU do not have to write it
+          again!</li>
+
+        <li><a href="http://sage.math.washington.edu/home/wdj/cookbook/coding-theory/sage-coding-cookbook.pdf"
+          >Linear Error-Correcting Codes</a> by David Joyner and
+          Robert Miller &mdash; introduces some of Sage's functionality in the
+          theory of error-correcting codes</li>
+
+        <li><a href="http://buzzard.ups.edu/sage/sage-group-theory-primer.pdf"
+          >Group Theory and Sage: A Primer</a> by Rob Beezer
+          &mdash; a compilation of Sage commands useful for a student studying
+          group theory for the first time</li>
+
+     </ul>
+  </ul>
+
+  <ul>
+     <li>General Tutorials and Books</li>
+     <ul>
+        <li><b><a href="http://www.gregorybard.com/SAGE.html">Gregory V. Bard - Sage for Undergraduates</a> (<a href="http://www.gregorybard.com/sage_for_undergraduates_color.pdf.zip">PDF</a>)</b> &mdash;
+         detailed introduction into Sage for undergraduates and others, who simply want to learn Sage.
+         Published by "The American Mathematical Society", 2014.</b></li>
+
+        <li><a href="http://arachnoid.com/sage/">
+            Exploring Mathematics with Sage</a> by Paul Lutus &mdash; overview
+          of using Sage in various areas of applied mathematics</li>
+
+        <li><a href="http://www-rohan.sdsu.edu/~mosulliv/Teaching/sdsu-sage-tutorial/index.html">Sage Tutorial</a> by Mike O'Sullivan, Ryan Rosenbaum, and  David Monarres</li>
+
+        <li><a href="https://www.uam.es/personal_pdi/ciencias/pangulo/laboratorio/sage_for_newbies_v1.23.pdf"
+          >Sage for Newbies</a> &mdash; book by T. Kosan
+          <ul>
+            <li>Spanish translation: <a href="./es/Manual_SAGE_principiantes.pdf">Manual de Sage
+	    para principiantes (Español)</a></li>
+	  </ul>
+        </li>
+        
+       </ul>
   </ul>
 
 <div class="normal justify bodypadding">


### PR DESCRIPTION
I think all things (currently, though in Sage 6.5 more will be there) in the doc are now listed as well.  Fixed a link - well, that is, William made most sage.math/home/user directories not readable, so I found another copy online.

I also tried to move things out of the standard documentation and into some more categories.  Really these should not be bullets but different header levels, but I stuck with what was there for now in the hopes it will be easy to review.
