### PR TITLE
Fix French links

### DIFF
--- a/src/fr/index.html
+++ b/src/fr/index.html
@@ -36,8 +36,8 @@ fonctionnalités du bloc-note. </div>
 Sage est principalement disponible en anglais. Une partie de sa
 documentation a cependant été traduite en français:
 <ul> 
-<li><a href="{{ 'doc-html/fr/a_tour_of_sage/'|prefix }}">Sage en quelques mots</a> ;</li>
-<li><a href="{{ 'doc-html/fr/html/tutorial/'|prefix }}">tutoriel</a>.</li>
+<li><a href="{{ './html/a_tour_of_sage/' }}">Sage en quelques mots</a> ;</li>
+<li><a href="{{ './html/tutorial/' }}">tutoriel</a>.</li>
 </ul> 
 L&#39;intégralité de la documentation en anglais est <a href="{{ 'doc/'|prefix }}">accessible
 ici</a>. Elle regroupe les versions originales (parfois plus à jour que


### PR DESCRIPTION
At least I hope so.  The first one already works, the second one was broken because it was had an extra `html` in the path.
