### PR TITLE
Remove "GAP Packages" link from the menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -174,7 +174,6 @@ or
  <li><a href="{{ 'download-latest.html'|prefix }}">Development Release</a></li>
  <li class="section"><a href="{{ 'download-livecd.html'|prefix }}">Live CD</a></li>
  <li class="section"><a href="{{ 'download-packages.html'|prefix }}">Packages (SPKG)</a></li>
- <li><a href="http://wiki.sagemath.org/InstallingGapPackages">GAP Packages</a></li>
  <li class="section"><a href="{{ docroot }}/html/en/installation">Install Guide</a></li>
 {# <li><a href="{{ 'mirror/src/changelogs/'|prefix }}">Release Notes</a></li> #}
  <li><a href="{{ 'mirrors.html'|prefix }}">Mirrors</a></li>


### PR DESCRIPTION
I do not think that there is a reason why instructions about "GAP Packages" should appear so high in the hierarchy. This link does not belong to the menu of Sage's website.