### PR TITLE
Remove broken interact.sagemath.org links

### DIFF
--- a/src/links.html
+++ b/src/links.html
@@ -8,8 +8,6 @@
   <li><a href="http://planet.sagemath.org/">Planet {{ sage }} Blogs</a> &mdash; 
         compilation of blogs by {{ sage }} developers</li>
 
-<li><a href="http://interact.sagemath.org/">Interact</a> &mdash; Interactive {{ sage }}-based tools and applications</li>
-
 <li><a href="https://sagecell.sagemath.org/">{{ sage }} Cell Server</a> &mdash; type some code to evaluate it immediately or embed it into your own website</li>
 
   <li><a href="http://wiki.sagemath.org/">{{ sage }} Wiki</a> &mdash; 

--- a/src/tour-education.html
+++ b/src/tour-education.html
@@ -11,8 +11,7 @@
   on calculations. This is done in a very general way using the basic functionality of Python.
   Therefore nearly every possible dependency could be shown. The following animation shows a slider
   on top, which can be dragged in the real case - the plot is then updated accordingly. -
-     <a href="http://wiki.sagemath.org/interact">see wiki</a> or
-     the <a href="http://interact.sagemath.org">Interact Website</a> for more examples</a>.
+     <a href="http://wiki.sagemath.org/interact">see the wiki</a> for more examples.
  </div>
 
  <div class="txt center">

--- a/templates/base.html
+++ b/templates/base.html
@@ -131,7 +131,6 @@ or
  <li><a href="{{ 'tour-benchmarks.html'|prefix }}">Benchmarks</a></li>
  <li class="section"><a href="http://wiki.sagemath.org/interact/">Interactive Plots (wiki)</a></li>
  <li><a href="{{ docroot }}/html/en/a_tour_of_sage/">A Tour of {{ sage }}</a></li>
- <li class="section"><a href="http://interact.sagemath.org" class="ext">{{ sage }} Interact Community</a></li>
 </ul>
 </li>
 
@@ -199,8 +198,7 @@ or
 <ul>
  <li><a href="{{ 'links.html'|prefix }}">Projects &amp; Software</a></li>
  <li><a href="{{ 'links-components.html'|prefix }}">{{ sage }} Components</a></li>
- <li class="section"><a href="http://interact.sagemath.org">{{ sage }} Interact Community</a></li>
- <li><a href="http://sagecell.sagemath.org/">{{ sage }} Cell Server</a></li>
+ <li class="section"><a href="http://sagecell.sagemath.org/">{{ sage }} Cell Server</a></li>
  <li class="section"><a href="http://planet.sagemath.org/">{{ sage }} Blog</a></li>
  <li><a href="http://wiki.sagemath.org/">{{ sage }} Wiki</a></li>
  <li><a href="http://spreadsheets.google.com/viewform?key=pCwvGVwSMxTzT6E2xNdo5fA">Report a Problem</a></li>


### PR DESCRIPTION
http://interact.sagemath.org/ redirects on William's home page. I sent him an email to ask him whether the website still existed somewhere, to which he answered by forwarding the question to Jason.

That was 11 days ago, and still no answer. We can still add it back if we hear from him, but in the meantime let's remove those broken links.

Nathann