### PR TITLE
Remove mupad bibliography

### DIFF
--- a/src/library-publications.html
+++ b/src/library-publications.html
@@ -5,8 +5,6 @@
   <h1>Publications Citing {{ sage }}</h1>
 
 <div class="normal justify bodypadding">
-See also the list of publications citing
-<a href="./library-publications-combinat.html">{{ sage }}-Combinat</a>.
 <p/>
 Below is a list of publications that cite {{ sage }} and/or the {{ sage }}
 cluster. This list is also available in
@@ -15,6 +13,11 @@ listed in each section are sorted in chronological order. Where two or more
 items are published in the same year, these items are sorted alphabetically
 by the authors' last names. See the section <a href="#CiteSage">Citing {{ sage }}</a>
 for information on how to cite {{ sage }} and/or the {{ sage }} cluster in your publications.
+
+<br><br>
+See also the list of publications citing
+<a href="./library-publications-combinat.html">{{ sage }}-Combinat</a> or
+<a href="./library-publications-mupad.html">MuPAD-Combinat</a>.
 </div>
 
 {% import 'publications-general.html' as pub %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -153,9 +153,7 @@ or
 <ul>
  <li><a href="{{ 'library.html'|prefix }}">Overview</a></li>
  <li><a href="{{ 'library-stories.html'|prefix }}">Testimonials</a></li>
- <li><a href="{{ 'library-publications.html'|prefix }}">Publications {{ sage }}</a></li>
- <li><a href="{{ 'library-publications-combinat.html'|prefix }}">Publications Combinat</a></li>
- <li><a href="{{ 'library-publications-mupad.html'|prefix }}">Publications Mupad</a></li>
+ <li><a href="{{ 'library-publications.html'|prefix }}">Publications</a></li>
  <li><a href="{{ 'library-publications.html#books'|prefix }}" >Books</a></li>
  <li><a href="{{ 'library-why.html'|prefix }}">Why?</a></li>
  <li><a href="{{ 'library-marketing.html'|prefix }}">Marketing</a></li>


### PR DESCRIPTION
Mupad-combinat has apparently been dead for the last 7 years.
http://mupad-combinat.sourceforge.net/

Regardless of that, Mupad is not part of Sage there is no reason why we should host its bibliography.