### PR TITLE
Update link to sympy on homepage

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -27,7 +27,7 @@ open-source packages:
 <a href="http://numpy.scipy.org/">NumPy</a>, 
 <a href="http://www.scipy.org/">SciPy</a>, 
 <a href="http://matplotlib.sourceforge.net/">matplotlib</a>,
-<a href="http://code.google.com/p/sympy/">Sympy</a>, 
+<a href="http://www.sympy.org/">Sympy</a>, 
 <a href="http://maxima.sourceforge.net/">Maxima</a>, 
 <a href="http://www.gap-system.org/">GAP</a>, 
 <a href="http://www.flintlib.org/">FLINT</a>, 


### PR DESCRIPTION
Since google code is archived, sympy has moved to http://www.sympy.org