### PR TITLE
link to renamed wiki page

### DIFF
--- a/src/library-publications.html
+++ b/src/library-publications.html
@@ -53,7 +53,7 @@ See also the list of publications citing
       <a href="../contact.html">contact us</a> about details of the
       publication, e.g. where it is published, provide a link to your
       publication. Please reference {{ sage }} as
-      <a href="http://wiki.sagemath.org/Publications_using_SAGE">described
+      <a href="http://wiki.sagemath.org/Publications_using_SageMath">described
       here</a>.
     </div>
 


### PR DESCRIPTION
I changed the wiki page to use SageMath consistently, and changed the page title. So the link here is broken and has to be changed.