### PR TITLE
Modify links for sage-mode

### DIFF
--- a/src/download.html
+++ b/src/download.html
@@ -171,7 +171,7 @@
 
      <div>
       <ul>
-       <li><a href="http://wiki.sagemath.org/sage-mode">{{ sage }} Emacs Mode</a> — helps to work with
+       <li><a href="https://github.com/stakemori/sage-shell-mode">{{ sage }} Emacs Mode</a> — helps to work with
        {{ sage }} in Emacs.</li>
 
        <li><a href="http://www.ctan.org/tex-archive/macros/latex/contrib/sagetex/">{{ sage }}Tex LaTeX

--- a/src/download.html
+++ b/src/download.html
@@ -171,7 +171,7 @@
 
      <div>
       <ul>
-       <li><a href="https://github.com/stakemori/sage-shell-mode">{{ sage }} Emacs Mode</a> — helps to work with
+       <li><a href="https://github.com/sagemath/sage-shell-mode">{{ sage }} Emacs Mode</a> — helps to work with
        {{ sage }} in Emacs.</li>
 
        <li><a href="http://www.ctan.org/tex-archive/macros/latex/contrib/sagetex/">{{ sage }}Tex LaTeX

--- a/templates/download-tmpl.html
+++ b/templates/download-tmpl.html
@@ -70,7 +70,7 @@ Utilities
 
      <div>
       <ul>
-       <li><a href="https://github.com/stakemori/sage-shell-mode">{{ sage }} Emacs Mode</a> — helps to work with
+       <li><a href="https://github.com/sagemath/sage-shell-mode">{{ sage }} Emacs Mode</a> — helps to work with
        {{ sage }} in Emacs.</li>
 
        <li><a href="http://www.ctan.org/tex-archive/macros/latex/contrib/sagetex/">SageTex LaTeX

--- a/templates/download-tmpl.html
+++ b/templates/download-tmpl.html
@@ -70,7 +70,7 @@ Utilities
 
      <div>
       <ul>
-       <li><a href="http://wiki.sagemath.org/sage-mode">{{ sage }} Emacs Mode</a> — helps to work with
+       <li><a href="https://github.com/stakemori/sage-shell-mode">{{ sage }} Emacs Mode</a> — helps to work with
        {{ sage }} in Emacs.</li>
 
        <li><a href="http://www.ctan.org/tex-archive/macros/latex/contrib/sagetex/">SageTex LaTeX


### PR DESCRIPTION
We plan to make `sage-mode` (an Emacs package for Sage) obsolete and make [sage-shell-mode](https://github.com/stakemori/sage-shell-mode) the default package, because `sage-mode` is broken in Sage 7.4 and Ivan Andrus (the current maintainer of `sage-mode`) said he doesn't have much time for working on it.

See [https://trac.sagemath.org/ticket/21227](https://trac.sagemath.org/ticket/21227) and [https://trac.sagemath.org/ticket/21549](https://trac.sagemath.org/ticket/21549).

Merging this pull request will modify the link in the download page.
