### PR TITLE
Improve HTTPS experience

### DIFF
--- a/src/res/sage.js
+++ b/src/res/sage.js
@@ -204,8 +204,8 @@ function initClustermap() {
  function _cantload() {
    var img = document.getElementById("clustrMapsImg");
    img.onerror = null;
-   img.src = "http://www2.clustrmaps.com/images/clustrmaps-back-soon.jpg";
-   document.getElementById("clustrMapsLink").href = "http://www2.clustrmaps.com";
+   img.src = "http://www.clustrmaps.com/images/clustrmaps-back-soon.jpg";
+   document.getElementById("clustrMapsLink").href = "http://www.clustrmaps.com";
  }
  var img = document.getElementById("clustrMapsImg");
  img.onerror = _cantload;

--- a/src/res/sage.js
+++ b/src/res/sage.js
@@ -204,8 +204,8 @@ function initClustermap() {
  function _cantload() {
    var img = document.getElementById("clustrMapsImg");
    img.onerror = null;
-   img.src = "http://www.clustrmaps.com/images/clustrmaps-back-soon.jpg";
-   document.getElementById("clustrMapsLink").href = "http://www.clustrmaps.com";
+   img.src = "https://www.clustrmaps.com/images/clustrmaps-back-soon.jpg";
+   document.getElementById("clustrMapsLink").href = "https://www.clustrmaps.com";
  }
  var img = document.getElementById("clustrMapsImg");
  img.onerror = _cantload;

--- a/templates/base.html
+++ b/templates/base.html
@@ -238,11 +238,11 @@ or
 <tr style="height: 70px;">
 <td align="right" colspan="1">
 
-<a style="background:none;" href="//www.clustrmaps.com/map/Sagemath.org">
+<a style="background:none;" href="https://www.clustrmaps.com/map/Sagemath.org">
     <img width="65" height="42"
     style="border:0px;"
     id="clustrMapsImg"
-    src="http://www.clustrmaps.com/stats/maps-no_clusters/sagemath.org-thumb.jpg" alt="Locations of visitors to this page" />
+    src="https://www.clustrmaps.com/stats/maps-no_clusters/sagemath.org-thumb.jpg" alt="Locations of visitors to this page" />
 </a>
 
 </td>

--- a/templates/base.html
+++ b/templates/base.html
@@ -242,7 +242,7 @@ or
     <img width="65" height="42"
     style="border:0px;"
     id="clustrMapsImg"
-    src="http://www3.clustrmaps.com/stats/maps-no_clusters/sagemath.org-thumb.jpg" alt="Locations of visitors to this page" />
+    src="http://www.clustrmaps.com/stats/maps-no_clusters/sagemath.org-thumb.jpg" alt="Locations of visitors to this page" />
 </a>
 
 </td>


### PR DESCRIPTION
Currently, the browser shows a warning accessing the [Web site over HTTPS](https://www.sagemath.org). Update the URLs to ClustrMaps.com to use HTTPS unconditionally.