### PR TITLE
Remove broken links on mirrors.html

### DIFF
--- a/src/mirrors.html
+++ b/src/mirrors.html
@@ -33,8 +33,6 @@ td {padding: 5px 0 5px 0; }
  </div>
 
 <div class="narrow txt center">
-{{ sage }} Mirror size stats, (thanks to <a href="http://ftp.sh.cvut.cz/WEB/index.html">CVUT.cz</a>):<br/>
-<img src="http://ftp.sh.cvut.cz/WEB/var/sagemath.png" />
 </div>
 <h2 class="narrow">Mirror List</h2>
  <div class="narrow txt">
@@ -43,7 +41,6 @@ td {padding: 5px 0 5px 0; }
   (master mirror), it is outdated. The current {{ sage }} version is {{ version }} released 
   {{ releasedate }}</strong>. 
   If you also want to help {{ sage }} by hosting a mirror, please <a href="./contact.html">contact us</a>.
-  Check status of <a href="./mirror_manager.txt">Mirror Management</a> script.
 
   <table class="">
      {% include "all-mirrors.html" %}


### PR DESCRIPTION
* The "mirror size stats" no longer works and appears to be gone
* The "check status" link is dead--I assume this is supposed to point to output from the latest run of the mirror_manager.py script, but it is not being copied when rendering the live site--since no one noticed, and since it seems a bit needlessly "technical" I just removed the link.