### PR TITLE
Add prominent link to the Windows installer download site

### DIFF
--- a/src/download-windows.html
+++ b/src/download-windows.html
@@ -13,32 +13,39 @@
  <div class="narrow large txt bluebg round">
 
  <div class="txt border ">
+    <p><strong>Note: </strong> For <strong>Windows</strong> installer binaries see the <a href="https://github.com/sagemath/sage-windows/releases">GitHub releases page</a>.</p>
   {{ mirrors("win") }}
  </div>
  </div>
 
  <h2 class="narrow">Usage</h2>
-   <div class="txt narrow"> To run {{ sage }} on Microsoft Windows you need
-      the following:<br>
-      <ol>
-      <li><a href="https://www.virtualbox.org/wiki/Downloads">VirtualBox</a>
-      for Windows </li>
-      <li>Download the "{{ sage }}" .ova file from one of the
-      Download Mirrors</li>
-      <li>Follow these <a href="http://wiki.sagemath.org/SageAppliance">additional instructions</a>.</li>
-     </ol>
-      The current VirtualBox solution provides you with an encapsulated
-      and tested system. It allows to use the {{ sage }} notebook in your web
-      browser with no noticeable speed loss compared to a native Linux
-      install.<br>
-      <br>
-   </div>
-   <h3 class="narrow">System requirements:</h3>
    <div class="txt narrow">
-     <ul>
-        <li>1 GB RAM</li>
-        <li>7 GB free disk space</li>
+      To run {{ sage }} on Microsoft Windows there are two options:
+      <ul>
+        <li>
+          For {{ sage }} 8.0 and up a native binary installer is now available.
+          To use the installer you will need:
+          <ol>
+            <li>A 64-bit version of Windows 7 or up; there is not currently a 32-bit build</li>
+            <li>Roughly 5 GB of free disk space (plus 1 GB for the installer file itself)
+            <li>Read these <a href="http://wiki.sagemath.org/SageAppliance">additional instructions</a>
+          </ol>
+        </li>
+        <li>
+          If you can't use the binary installer for some reason, or simply
+          prefer the {{ sage }} VirtualBox appliance, you can us it with the following:
+          <ol>
+           <li><a href="./download-windows.html">Image of a {{ sage }} installation for virtualization</a></li>
+           <li>Read these <a href="http://wiki.sagemath.org/SageAppliance">additional instructions</a>
+          </ol>
+          <p>
+            The current VirtualBox solution provides you with an encapsulated
+            and tested system. It allows to use the {{ sage }} notebook in your web
+            browser with no noticable speed loss compared to a native Linux
+            install.
+          </p>
+        </li>
       </ul>
-    </div>
+   </div>
 
 {% endblock %}

--- a/src/download.html
+++ b/src/download.html
@@ -19,7 +19,8 @@
  </div>
 
  <div class="narrow txt border bluebg round">
-  <div  class="large txt">  
+  <div  class="large txt">
+    <p><strong>Note: </strong> For <strong>Windows</strong> installer binaries see the <a href="https://github.com/sagemath/sage-windows/releases">GitHub releases page</a>.</p>
     {{ mirrors("") }}
   </div>
  </div>
@@ -43,19 +44,34 @@
 
     <td>
      <div class="txt">
-      To run {{ sage }} on Microsoft Windows you need the following:
-      <ol>
-       <li><a href="./download-windows.html">Image of a {{ sage }} installation for virtualization</a></li>
-       <li>Read these <a href="http://wiki.sagemath.org/SageAppliance">additional instructions</a>
-      </ol>
+      <a href="./download-windows.html">Download Windows binaries</a>
      </div>
-
-     <div class="">
-      The current VirtualBox solution provides you with an encapsulated
-      and tested system. It allows to use the {{ sage }} notebook in your web
-      browser with no noticable speed loss compared to a native Linux
-      install.
-     </div>
+      To run {{ sage }} on Microsoft Windows there are two options:
+      <ul>
+        <li>
+          For {{ sage }} 8.0 and up a native binary installer is now available.
+          To use the installer you will need:
+          <ol>
+            <li>A 64-bit version of Windows 7 or up; there is not currently a 32-bit build</li>
+            <li>Roughly 5 GB of free disk space (plus 1 GB for the installer file itself)
+            <li>Read these <a href="http://wiki.sagemath.org/SageAppliance">additional instructions</a>
+          </ol>
+        </li>
+        <li>
+          If you can't use the binary installer for some reason, or simply
+          prefer the {{ sage }} VirtualBox appliance, you can us it with the following:
+          <ol>
+           <li><a href="./download-windows.html">Image of a {{ sage }} installation for virtualization</a></li>
+           <li>Read these <a href="http://wiki.sagemath.org/SageAppliance">additional instructions</a>
+          </ol>
+          <p>
+            The current VirtualBox solution provides you with an encapsulated
+            and tested system. It allows to use the {{ sage }} notebook in your web
+            browser with no noticable speed loss compared to a native Linux
+            install.
+         </p>
+        </li>
+      </ul>
     </td>
    </tr>
 


### PR DESCRIPTION
 (at least until we get the Windows installer on the mirrors) and add additional information pointing readers to the Windows installer before the VirtualBox appliance.

Should resole sagemath/sage-windows#4.

See also https://wiki.sagemath.org/SageWindows (linked to in the updated HTML) where I've placed more detailed information on the Windows version for ease of updating.