### PR TITLE
fix broken download links on changelogs/index.html

### DIFF
--- a/src/res/sage.js
+++ b/src/res/sage.js
@@ -34,10 +34,10 @@ var sage = {
     */
 
     downloadUrl: function() {
-        if (isWindows) return "download-windows.html";
-        if (isMac)     return "download-mac.html";
-        if (isLinux)   return "download-linux.html";
-        return "download.html";
+        if (isWindows) return "/download-windows.html";
+        if (isMac)     return "/download-mac.html";
+        if (isLinux)   return "/download-linux.html";
+        return "/download.html";
     },
 
     setDownloadUrls: function () {


### PR DESCRIPTION
There are two broken links on http://www.sagemath.org/changelogs/index.html; they are at the top right, the links "Download" and "v8.3 (2018-08-03)", which link to the Sage binary download page. This is ultimately caused by incorrect relative URLs in the `downloadUrl` function in `src/res/sage.js` which point to e.g. http://www.sagemath.org/changelogs/download-mac.html rather than http://www.sagemath.org/download-mac.html.