### PR TITLE
fix broken links in fr documentation

### DIFF
--- a/src/fr/_fr.html
+++ b/src/fr/_fr.html
@@ -11,7 +11,7 @@
 
 {% block menu %}
 <li id="intro"><a href="/fr/index.html">Index</a></li>
-<li id="plotting"><a href="/fr/telecharger.html">Telecharger</a></li>
+<li id="plotting"><a href="/fr/telecharger.html">Télécharger</a></li>
 <li id="documentation"><a href="/fr/documentation.html">Documentation</a></li>
 <li id="components"><a href="/fr/components.html">Components</a></li>
 {% endblock %}

--- a/src/fr/_fr.html
+++ b/src/fr/_fr.html
@@ -2,7 +2,7 @@
 {% set title = "Français" %}
 
 {% block logo_title %}
-<a href="./index.html">Français</a>
+<a href="/fr/index.html">Français</a>
 {% endblock %}
 
 {% block header_text %}
@@ -10,10 +10,10 @@
 {% endblock %}
 
 {% block menu %}
-<li id="intro"><a href="./index.html">Index</a></li>
-<li id="plotting"><a href="./telecharger.html">Telecharger</a></li>
-<li id="documentation"><a href="./documentation.html">Documentation</a></li>
-<li id="components"><a href="./components.html">Components</a></li>
+<li id="intro"><a href="/fr/index.html">Index</a></li>
+<li id="plotting"><a href="/fr/telecharger.html">Telecharger</a></li>
+<li id="documentation"><a href="/fr/documentation.html">Documentation</a></li>
+<li id="components"><a href="/fr/components.html">Components</a></li>
 {% endblock %}
 
 {% block header %}


### PR DESCRIPTION
The links "Français", ""Index", "Telecharger", "Documentation", "Components" are broken on the following four pages:
- http://www.sagemath.org/fr/48/W_UE_Courbes_param%C3%A9tr%C3%A9es_v02.html
- http://www.sagemath.org/fr/55/W_UE_Graphiques_Utilisation_avanc%C3%A9e_v04.html
- http://www.sagemath.org/fr/61/W_UE_Definir_une_fonction_v03.html
- http://www.sagemath.org/fr/62/W_UE_Tracer_des_graphes_v07.html
This is due to incorrect relative URLs in the template `src/fr/_fr.html`.

I also take the liberty of correcting "Telecharger" to "Télécharger".