### PR TITLE
"Polytechnic of Namibia" now "NUST"

### DIFF
--- a/conf/mirrors.yaml
+++ b/conf/mirrors.yaml
@@ -133,8 +133,8 @@
   cat: af
   country: na
   flag: na
-  name: Polytechnic of Namibia
-  url: http://sagemath.polytechnic.edu.na/
+  name: Namibia University of Science and Technology (NUST)
+  url: http://sagemath.nust.na/sage/
 - active: true
   cat: af
   country: za


### PR DESCRIPTION
Following the change of name of"Polytechnic of Namibia" to
"Namibia University of Science and Technology (NUST)" in 2015,
their website moved from polytechnic.edu.na to nust.na.