### PR TITLE
Fix wiki link on Debian packaging

### DIFF
--- a/src/download.html
+++ b/src/download.html
@@ -102,7 +102,7 @@
 
      <div class="">
       At the moment there are no distribution-specific packages available. Progress is being made
-      for <a href="http://wiki.sagemath.org/DebianSAGE"
+      for <a href="https://wiki.sagemath.org/devel/DebianSage"
           >Debian</a> 
            <!--(later maybe in <a href="">Scientific Ubuntu</a>)--> and <a href=
            "http://fedoraproject.org/wiki/SIGs/SciTech/SAGE"


### PR DESCRIPTION
The link 404'd, I think this is the page that was meant.