### PR TITLE
Fix OpenDreamKit funding: EC not ERC

### DIFF
--- a/src/development-ack.html
+++ b/src/development-ack.html
@@ -102,12 +102,13 @@
     </ul>
   </li>
 
-  <li><strong>European Research Council</strong>
+  <li><strong>European Commission 🇪🇺</strong>
     <ul>
-      <li><a href="http://cordis.europa.eu/project/rcn/198334_en.html">H2020 grant &#35;676541</a>
-      (September 2015 &#8211; August 2019)
-      <a href="http://opendreamkit.org/">OpenDreamKit</a>: develop a flexible toolkit enabling research groups
-      to set up Virtual Research Environments</li>
+      <li><a href="http://cordis.europa.eu/project/rcn/198334_en.html">Horizon 2020
+      European Research Infrastructures grant &#35;676541</a> (September 2015 &#8211; August 2019):
+      <a href="http://opendreamkit.org/">OpenDreamKit</a> (Open digital research environment
+      toolkit for the advancement of mathematics) &#8211; develop a flexible toolkit enabling
+      research groups to set up Virtual Research Environments</li>
     </ul>
   </li>
 


### PR DESCRIPTION
"Horizon 2020 European Research Infrastructure" is under
European Commission, not European Research Council.