### PR TITLE
Further macOS updates

### DIFF
--- a/src/download-mac.html
+++ b/src/download-mac.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
-{% set title = "Download Binaries for Apple's macOS" %}
+{% set title = "Download Binaries for Apple macOS" %}
 {% from "mirrorselector.html" import mirrors %}
 
 {% block content %}
 
- <h1 class="narrow">Download Binaries for Apple's macOS</h1>
+ <h1 class="narrow">Download Binaries for Apple macOS</h1>
 
  <div class="txt narrow">
    These binaries are for all recent versions of macOS.  Usually the

--- a/src/download-source.html
+++ b/src/download-source.html
@@ -29,7 +29,7 @@
 
  <div class="narrow txt">
   Thank you for your interest in {{ sage }}! You can get the complete source for {{ sage }} to compile it on
-  your own Linux or Mac OS X system. {{ sage }} lives in an isolated directory and does not interfere with
+  your own Linux or macOS system. {{ sage }} lives in an isolated directory and does not interfere with
   your surrounding system. It ships together with everything necessary to develop {{ sage }}, the source
   code, all its dependencies and the complete changelog.
  </div>

--- a/src/download.html
+++ b/src/download.html
@@ -18,12 +18,16 @@
   </form>
  </div>
  <div class="narrow xlarge txt bluebg round">
-   <strong>Note: </strong> For <strong>Windows</strong> installer binaries see the <a href="https://github.com/sagemath/sage-windows/releases">GitHub releases page</a>.
-</div>
+   <strong>Note: </strong> For <strong>Windows</strong> installer
+   binaries see the Windows
+   <a href="https://github.com/sagemath/sage-windows/releases">GitHub
+   releases page</a>.<br>
 
- <div class="narrow large txt">
-   Below are the VirtualBox images:
+  <strong>Note: </strong> For the recommended <strong>macOS</strong>
+  binaries see the macOS <a href="https://github.com/3-manifolds/Sage_macOS/releases">GitHub
+  releases page</a>.
  </div>
+
  <div class="narrow txt border bluebg round">
   <div  class="large txt">
     {{ mirrors("") }}
@@ -103,7 +107,7 @@
      <div class="">
       At the moment there are no distribution-specific packages available. Progress is being made
       for <a href="https://wiki.sagemath.org/devel/DebianSage"
-          >Debian</a> 
+          >Debian</a>
            <!--(later maybe in <a href="">Scientific Ubuntu</a>)--> and <a href=
            "http://fedoraproject.org/wiki/SIGs/SciTech/SAGE"
           >Fedora</a>.
@@ -113,17 +117,16 @@
 
 
    <tr>
-    <th>Apple Mac OS X</th>
+    <th>Apple macOS</th>
 
     <td>
      <div class="txt">
-      <a href="./download-mac.html">Download Mac OS X binaries</a>
+      <a href="./download-mac.html">Download macOS binaries</a>
      </div>
 
      <div>
-      These binaries are primarily for the versions mentioned in the filenames. They will not work on OS X 10.3. Usually
-      the binary for a version or two before your should work, e.g. 10.7 should work on 10.8.  For more
-      information <a href="http://files.sagemath.org/osx/README.txt">read the installation instructions</a>.
+       For more information <a href="https://doc.sagemath.org/html/en/installation/binary.html#macos">
+       read the installation instructions</a>.
      </div>
     </td>
    </tr>

--- a/src/fr/telecharger.html
+++ b/src/fr/telecharger.html
@@ -8,7 +8,7 @@
 
 
 <div class="txt"><a href="http://sagemath.org/download-linux.html">Binaires Linux</div>
-<div class="txt"><a href="http://sagemath.org/download.html">Binaires (autres OS : Windows, Max OS X, Solaris, ...)</div>
+<div class="txt"><a href="http://sagemath.org/download.html">Binaires (autres OS : Windows, macOS, Solaris, ...)</div>
 <div class="txt"><a href="http://sagemath.org/download-source.html">Sources</div>
 <div class="txt"><a href="http://sagemath.org/download-packages.html">Packages</div>
 

--- a/src/sage-pad.xml
+++ b/src/sage-pad.xml
@@ -42,7 +42,7 @@
 		<Program_Type>Freeware</Program_Type>
 		<Program_Release_Status>New Release</Program_Release_Status>
 		<Program_Install_Support>No Install Support</Program_Install_Support>
-		<Program_OS_Support>WinXP,Unix,Linux,Linux GPL,Linux Open Source,Mac OS X</Program_OS_Support>
+		<Program_OS_Support>WinXP,Unix,Linux,Linux GPL,Linux Open Source,macOS</Program_OS_Support>
 		<Program_Language>English</Program_Language>
 		<Program_Change_Info />
 		<Program_Specific_Category>Education</Program_Specific_Category>

--- a/templates/base.html
+++ b/templates/base.html
@@ -157,7 +157,7 @@ or
 <li><a href="{{ 'download.html'|prefix }}">Download</a>
 <ul>
  <li><a href="{{ 'download-windows.html'|prefix }}">Windows</a></li>
- <li><a href="{{ 'download-mac.html'|prefix }}">Mac OSX</a></li>
+ <li><a href="{{ 'download-mac.html'|prefix }}">macOS</a></li>
  <li><a href="{{ 'download-linux.html'|prefix }}">Linux</a></li>
  <li class="section"><a href="{{ 'download-source.html'|prefix }}">Source (stable)</a></li>
 {# <li><a href="{{ 'src-old/'|prefix }}">Old Source</a></li> #}

--- a/templates/download-tmpl.html
+++ b/templates/download-tmpl.html
@@ -34,7 +34,7 @@ DVD
      </div>
 
      <div>
-      It includes the full source code, binaries for the VMWare Player, Mac OS X and Linux and as
+      It includes the full source code, binaries for the VMWare Player, macOS and Linux and as
       well the documentation. Additionally, in the spirit of open-source you are allowed to copy
       and distribute this DVD freely! It may not contain the latest version, please check it on the
       website.

--- a/templates/mirror/index.html
+++ b/templates/mirror/index.html
@@ -100,7 +100,7 @@ tr.odd, tr.even {background: #f0f0fff;}
 
   <li><a href="./linux/index.html"><strong>Linux</strong></a> — binaries, for 32 and 64 bit</li>
 
-  <li><a href="./osx/index.html">Apple <strong>Mac OS X</strong></a> — binaries for Intel and PowerPC systems</li>
+  <li><a href="./osx/index.html">Apple <strong>macOS</strong></a> — binaries for Intel and PowerPC systems</li>
   
   <li><a href="./solaris/index.html"><strong>Oracle Solaris</strong></a> — binary and source</li>
   


### PR DESCRIPTION
1. Changed "download.html" to match "download-mac.html" following pattern
   for cygwin.  Sorry for not being complete the first time.

2. General update of "(Mac) OS X" to "macOS" as name changed in 2016.