### PR TITLE
Remove links to git.sagemath.org

### DIFF
--- a/src/development-status.html
+++ b/src/development-status.html
@@ -4,6 +4,10 @@
 {% block content %}
  <h1 class="narrow">Status of Development</h1>
 
+ <h2 class="narrow">Release Tour for the current development series</h2>
+
+ The <a href="https://wiki.sagemath.org/ReleaseTours">release notes for the current development series</a> are developed by collaborative editing on the Sage Wiki.
+
  <h2 class="narrow">Trac</h2>
 
  <table class="top narrow">

--- a/src/development-status.html
+++ b/src/development-status.html
@@ -16,11 +16,10 @@
     <td>
      <div class="txt">
       Trac is the organization tool for developing new code. Below, a quick view what&#39;s
-      currently happening. For more detailed information click
-         <a href="https://trac.sagemath.org/timeline">here</a>,
-         <a href="https://git.sagemath.org/sage.git/">here</a>
-         or read the
-         <a href="https://trac.sagemath.org/">introduction</a>.
+      currently happening. For more detailed information see
+      <ul>
+      <li> <a href="https://trac.sagemath.org/timeline">Trac development timeline</a>,
+      <li> <a href="https://trac.sagemath.org/">Trac main page</a>.
      </div>
     </td>
    </tr>

--- a/src/development-status.html
+++ b/src/development-status.html
@@ -24,6 +24,7 @@
       <ul>
       <li> <a href="https://trac.sagemath.org/timeline">Trac development timeline</a>,
       <li> <a href="https://trac.sagemath.org/">Trac main page</a>.
+      </ul>
      </div>
     </td>
    </tr>

--- a/src/download-source.html
+++ b/src/download-source.html
@@ -43,6 +43,11 @@
   <p>
     See also <a href="https://wiki.sagemath.org/ReleaseTours/sage-{{version_src}}">Release Tour for version {{version_src}}</a> and the <a href="changelogs/sage-{{version_src}}.txt">changelog</a>.<br />
   <p>
-  You can <a href="https://github.com/sagemath/sage/">browse the Sage repository on GitHub</a>.<br />
+    You can <a href="https://github.com/sagemath/sage/">browse the main Sage repository on GitHub</a>.
+    The <a href="https://github.com/sagemath">SageMath organization on GitHub</a>
+    also hosts a number of other repositories.
+  <p>
+    Sage also makes use of numerous other open source <a href="https://doc.sagemath.org/html/en/reference/spkg/">software packages</a>, which are maintained separately.<br />
+
  </div>
 {% endblock %}

--- a/src/download-source.html
+++ b/src/download-source.html
@@ -54,9 +54,6 @@
   <p>
     See also <a href="https://wiki.sagemath.org/ReleaseTours/sage-{{version_src}}">Release Tour for version {{version_src}}</a> and the <a href="changelogs/sage-{{version_src}}.txt">changelog</a>.<br />
   <p>
-  You can <a href=
-  "https://git.sagemath.org/">browse all the
-  tracked source code repositories</a> and see exactly what&#39;s going on, and who did what
-  when.<br />
+  You can <a href="https://github.com/sagemath/sage/">browse the Sage repository on GitHub</a>.<br />
  </div>
 {% endblock %}

--- a/src/download-source.html
+++ b/src/download-source.html
@@ -31,21 +31,10 @@
   Thank you for your interest in {{ sage }}! You can get the complete source for {{ sage }} to compile it on
   your own Linux or macOS system. {{ sage }} lives in an isolated directory and does not interfere with
   your surrounding system. It ships together with everything necessary to develop {{ sage }}, the source
-  code, all its dependencies and the complete changelog.
+  code and all its standard dependencies.
  </div>
 
  <div class="txt narrow">
-  Short instructions:
-
-  <ol>
-   <li>Extract archive</li>
-
-   <li>Start compiling: <span class="code">make</span></li>
-
-   <li>Run {{ sage }}: <span class="code">./sage</span></li>
-
-   <li>Upgrade to newer version later: <span class="code nowrap">./sage -upgrade</span></li>
-  </ol>
 
   Please read the <a href="https://github.com/sagemath/sage/blob/master/README.md">README</a> and the 
   <a href="{{ docroot }}/html/en/installation/">installation guide</a> for more details, which also

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@
 <div class="hidden"><img src="./pix/index_icons-nq8.png" alt="" /></div>
 <div class="narrow txt topmargin" id="idx1" track="index-top">
   <strong class="large">{{ sage }}</strong> is a free <a href=
-  "https://git.sagemath.org/">open-source</a>
+  "https://github.com/sagemath/sage/">open-source</a>
   mathematics software system licensed under the GPL.
 It builds on top of many existing 
 open-source packages:
@@ -151,7 +151,7 @@ if (data) {
       &middot; </span> 
       {# <span class="nowrap"><a href="./download-liveusb.html">Live USB Key</a> &middot; </span> #}
       {# <a href="./download-packages.html">Packages</a> &middot; #}
-      <a href="https://git.sagemath.org/sage.git/">Git</a>
+      <a href="https://github.com/sagemath/sage/">Git</a>
      </div>
     </td>
    </tr>


### PR DESCRIPTION
... in favor of linking to GitHub.

@dimpase 