### PR TITLE
Fixed broken video link

### DIFF
--- a/src/help-video.html
+++ b/src/help-video.html
@@ -49,7 +49,7 @@ Author: David Joyner, US Naval Academy<br/>
 Date: April 22, 2011<p>
 Systems of differential equations can be used to mathematically model the weather, electrical networks, spread of infectious diseases, conventional battles, populations of competing species, and, yes, zombie attacks. This talk looks at some of these models from the computational perspective using the mathematical software {{ sage }}.
 <p>
-<a href="http://www.mosaic-web.org/MCAST/videos/MCAST-2011-04-22/lib/playback.html">Video</a><br/>
+<a href="https://www.youtube.com/watch?v=z3MAPweScz8">Video</a><br/>
 <a href="files/love-war-zombies_slides.pdf">Slides</a>
 </p>
 </div>


### PR DESCRIPTION
I solved "Video link broken for: Modeling in SageMath: Love, War, and Zombies #222" wherein I just replaced the old link (not working "http://www.mosaic-web.org/MCAST/videos/MCAST-2011-04-22/lib/playback.html") with updated link "https://www.youtube.com/watch?v=z3MAPweScz8" which is working fine.