### PR TITLE
fix links to public calctutorial project

### DIFF
--- a/src/calctut/_calctut.html
+++ b/src/calctut/_calctut.html
@@ -17,8 +17,8 @@
       <i>
       This lesson is also available as executable worksheets on CoCalc.
       First, create an account and a project.  Then you can copy these files to your project and start working right away.
-      <a href="https://cocalc.com/projects/487587b1-8b24-401a-92d9-a9b930edd53d/files/JUPYTER/{{ basename }}.ipynb?utm_source=sagemath.org&amp;utm_medium=calctut">{{ basename }}.ipynb (Jupyter Notebook)</a> and
-      <a href="https://cocalc.com/projects/487587b1-8b24-401a-92d9-a9b930edd53d/files/SAGEWS/{{ basename }}.sagews?utm_source=sagemath.org&amp;utm_medium=calctut">{{ basename }}.sagews (SageMath Worksheet)</a>.
+      <a href=""https://cocalc.com/hsnyder/calctutorial/jupyter?utm_source=sagemath.org&amp;utm_medium=calctut">{{ basename }}.ipynb (Jupyter Notebook)</a> and
+      <a href=""https://cocalc.com/hsnyder/calctutorial/sagews?utm_source=sagemath.org&amp;utm_medium=calctut">{{ basename }}.sagews (SageMath Worksheet)</a>.
       </i>
     </div>
 </div>

--- a/src/calctut/index.html
+++ b/src/calctut/index.html
@@ -23,7 +23,7 @@
   <a href="https://cocalc.com/?utm_source=sagemath.org&amp;utm_medium=calctut">CoCalc</a>!
   First, create an account and a project.
   Then you can get a copy of the files
-  <a href="https://cocalc.com/projects/487587b1-8b24-401a-92d9-a9b930edd53d/files/?utm_source=sagemath.org&amp;utm_medium=calctut">from here</a>!
+  <a href="https://cocalc.com/hsnyder/calctutorial">from here</a>!
   </div>
 </div>
   <p>


### PR DESCRIPTION
Clicking the three links led to a CoCalc session waiting for sign-in. These edits take you to a public project, no authentication needed. 

The new version of the link in index.html does not work if you add the query string with utm_ parameters.