### PR TITLE
Remove outdated duplicate info for Gutow

### DIFF
--- a/conf/contributors.xml
+++ b/conf/contributors.xml
@@ -1486,11 +1486,6 @@ Please keep the list in alphabetical order by last name!
  github="gutow"
  url="https://cms.gutow.uwosh.edu/Gutow"/>
 <contributor
- name="Jonathan Gutow"
- location="Univ. Wisc. Oshkosh"
- url="http://www.uwosh.edu/facstaff/gutow"
- trac="gutow"/>
-<contributor
  name="Jose Guzman"
  work="Institute of Science and Technology Austria"
  location="Am Campus 1, 3400 Klosterneuburg, Austria"


### PR DESCRIPTION
Remove the second occurrence of my name as it points to an outdated website. My location and affiliations have not changed.