### PR TITLE
Fix contributor information for Antoine Leudière

### DIFF
--- a/conf/contributors.xml
+++ b/conf/contributors.xml
@@ -2932,7 +2932,7 @@ Please keep the list in alphabetical order by last name!
  description="drinfeld modules; cryptography"
  url="https://members.loria.fr/ALeudiere/"
  trac="antoine-leudiere"
- github="kryzar"/>
+ github="antoine-leudiere"/>
 <contributor
  name="Duncan Levear"/>
 <contributor


### PR DESCRIPTION
This is a fix of #357, in which I added my contributor information for the migration from Trac to Github. I realised that I should instead a dedicated account for my professional activities. This pull request replaces my personal account by my professional account.

Apologies for the duplicate work.

Best,
Antoine Leudière