### PR TITLE
Remove RSS feed links

### DIFF
--- a/src/development-groups.html
+++ b/src/development-groups.html
@@ -32,12 +32,6 @@
           <li>If you have problems subscribing, <a href=
           "./contact.html">contact us</a>.
           </li>
-
-          <li>
-            <a href=
-            "http://groups.google.com/group/sage-devel/feed/atom_v1_0_msgs.xml">
-            RSS Feed</a>
-          </li>
         </ul>
       </td>
       <td class="rightpadding">
@@ -59,12 +53,6 @@
 
           <li>If you have problems subscribing, <a href=
           "./contact.html">contact us</a>.
-          </li>
-
-          <li>
-            <a href=
-            "http://groups.google.com/group/sage-combinat-devel/feed/atom_v1_0_msgs.xml">
-            RSS Feed</a>
           </li>
         </ul>
       </td>
@@ -100,12 +88,6 @@
           <li>If you have problems subscribing, <a href=
           "./contact.html">contact us</a>.
           </li>
-
-          <li>
-            <a href=
-            "http://groups.google.com/group/sage-nt/feed/atom_v1_0_msgs.xml">RSS
-            Feed</a>
-          </li>
         </ul>
       </td>
       <td class="rightpadding">
@@ -127,12 +109,6 @@
 
           <li>If you have problems subscribing, <a href=
           "./contact.html">contact us</a>.
-          </li>
-
-          <li>
-            <a href=
-            "http://groups.google.com/group/sage-windows/feed/atom_v1_0_msgs.xml">
-            RSS Feed</a>
           </li>
         </ul>
       </td>
@@ -170,12 +146,6 @@
           <li>If you have problems subscribing, <a href=
           "./contact.html">contact us</a>.
           </li>
-
-          <li>
-            <a href=
-            "http://groups.google.com/group/sage-release/feed/atom_v1_0_msgs.xml">
-            RSS Feed</a>
-          </li>
         </ul>
       </td>
       <td class="rightpadding">
@@ -197,12 +167,6 @@
 
           <li>If you have problems subscribing, <a href=
           "./contact.html">contact us</a>.
-          </li>
-
-          <li>
-            <a href=
-            "http://groups.google.com/group/sage-coding-theory/feed/atom_v1_0_msgs.xml">
-            RSS Feed</a>
           </li>
         </ul>
       </td>
@@ -228,12 +192,6 @@
 
           <li>If you have problems subscribing, <a href=
           "./contact.html">contact us</a>.
-          </li>
-
-          <li>
-            <a href=
-            "http://groups.google.com/group/sage-finance/feed/atom_v1_0_msgs.xml">
-            RSS Feed</a>
           </li>
         </ul>
       </td>
@@ -271,12 +229,6 @@
           <li>If you have problems subscribing, <a href=
           "./contact.html">contact us</a>.
           </li>
-
-          <li>
-            <a href=
-            "http://groups.google.com/group/sage-edu/feed/atom_v1_0_msgs.xml">RSS
-            Feed</a>
-          </li>
         </ul>
       </td>
       <td class="rightpadding">
@@ -296,12 +248,6 @@
 
           <li>If you have problems subscribing, <a href=
           "./contact.html">contact us</a>.
-          </li>
-
-          <li>
-            <a href=
-            "http://groups.google.com/group/sage-grid/feed/atom_v1_0_msgs.xml">RSS
-            Feed</a>
           </li>
         </ul>
       </td>

--- a/src/help-groups.html
+++ b/src/help-groups.html
@@ -34,9 +34,6 @@
       <li>
       If you have problems subscribing, <a href="./contact.html">contact us</a>.
       </li>
-
-      <li><a href="http://groups.google.com/group/sage-support/feed/atom_v1_0_msgs.xml">RSS
-      Feed</a></li>
      </ul>
     </td>
 
@@ -55,9 +52,6 @@
       <li>
       If you have problems subscribing, <a href="./contact.html">contact us</a>.
       </li>
-
-      <li><a href="http://groups.google.com/group/sage-edu/feed/atom_v1_0_msgs.xml">RSS
-      Feed</a></li>
      </ul>
     </td>
    </tr>
@@ -84,7 +78,9 @@
       <li><a href="http://groups.google.com/group/sage-algebra/"
         >sage-algebra</a> – online</li>
 
-      <li><a href="http://groups.google.com/group/sage-algebra/feed/atom_v1_0_msgs.xml">RSS Feed</a></li>
+      <li>
+      If you have problems subscribing, <a href="./contact.html">contact us</a>.
+      </li>
      </ul>
     </td>
 


### PR DESCRIPTION
Google Groups killed RSS support a couple years ago.  The RSS feed links now just forward to the group instead of actually providing a feed.

This pull request therefore removes those links.