### PR TITLE
Remove links to inactive/broken https://planet.sagemath.org/

### DIFF
--- a/src/contact.html
+++ b/src/contact.html
@@ -25,7 +25,7 @@
    <li><a href="{{ webmaster_href }}" >
    Harald Schilly</a>: webmaster, website,
        <a href="{{ 'mirrors.html'|prefix }}">mirrors (rsync)</a>,
-       <a href="http://planet.sagemath.org">Planet {{ sage }}</a>, press,
+       Planet {{ sage }}, press,
      publications list, website,  mailing lists, infrastructure, older versions, ...
    </li>
 

--- a/src/help.html
+++ b/src/help.html
@@ -216,9 +216,6 @@ The
         <li><a href="./library-publications.html#books">Books</a> &mdash; a collection of
           online books explaining mathematics (calculus, linear algebra,
           number theory, etc.) using {{ sage }}</li>
-        <li><a href="http://planet.sagemath.org/"
-          >Planet {{ sage }} Blogs</a> &mdash; a collection of blogs by
-          {{ sage }} users and developers</li>
         <li><a href="./search.html"><strong>Search</strong></a> &mdash; an
           online search interface indexing {{ sage }} documentation, discussion
           groups, various web resources, blogs and various other places on

--- a/src/index.html
+++ b/src/index.html
@@ -266,7 +266,6 @@ var rlinks = [
     ["tour-quickstart.html", "Quickstart into {{ sage }}"],
     ["development-map.html", "Map of all {{ sage }} developers"],
     ["tour.html", "Introduction to {{ sage }}"],
-    ["http://planet.sagemath.org/", "{{ sage }} Blog"],
     ["http://www.ctan.org/tex-archive/help/Catalogue/entries/sagetex.html", "SageTeX - embedding {{ sage }} code inside LaTeX documents."],
     ["library-stories.html", "Success Stories, Testimonials, News Articles, Blogs"],
     ["library-publications.html", "Publications citing {{ sage }}"],

--- a/src/index.html
+++ b/src/index.html
@@ -143,7 +143,8 @@ if (data) {
         <h2><a href="https://doc.sagemath.org/html/en/installation/index.html">Install {{version}}</a></h2>
 
      <div class="small">
-        <span class="nowrap"><a href="https://github.com/sagemath/sage/releases">Releases</a>
+       <span class="nowrap"><a href="https://github.com/sagemath/sage/releases">Releases</a>
+         &middot; </span>
          {#<span class="nowrap"><a href="https://wiki.sagemath.org/ReleaseTours/">Release Tours</a>
        &middot; </span>#}
          {#<span class="nowrap"><a href="changelogs/index.html">Changelogs</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -46,8 +46,6 @@
 <form action="{{ 'search.html'|prefix }}" method="get">
 <a href="https://github.com/sagemath/sage">GitHub</a>
 &middot;
-<a href="http://planet.sagemath.org/">Blog</a>
-&middot;
 <a href="https://wiki.sagemath.org/">Wiki</a>
 &middot;
 <a href="https://ask.sagemath.org/">Questions?</a>
@@ -175,7 +173,6 @@ or
  <li><a href="https://github.com/sagemath/sage/wiki/WikiStart#surveying-the-mathematical-software-landscape" class="ext">Math Software Landscape</a></li>
  <li><a href="https://doc.sagemath.org/html/en/reference/spkg/" class="ext">{{ sage }} Components</a></li>
  <li class="section"><a href="https://sagecell.sagemath.org/" class="ext">{{ sage }} Cell Server</a></li>
- <li class="section"><a href="http://planet.sagemath.org/" class="ext">{{ sage }} Blog</a></li>
  <li><a href="https://wiki.sagemath.org/">{{ sage }} Wiki</a></li>
  <li><a href="https://groups.google.com/forum/#!forum/sage-devel">Report a bug</a></li>
  {# <li class="section"><a href="https://secure.gifts.washington.edu/as_mathematics/gift.asp?page=make&amp;Code=MATSAG" class="ext">Donate</a></li> #}


### PR DESCRIPTION
https://planet.sagemath.org/ has no content newer than Dec 2020, overall very limited content, and the top item contains broken links.

Cc @williamstein @seblabbe


