### PR TITLE
Add Cyril Bouvier in contributors.xml

### DIFF
--- a/conf/contributors.xml
+++ b/conf/contributors.xml
@@ -552,6 +552,13 @@ Please keep the list in alphabetical order by last name!
  name="Adrien Boussicault"
  trac="boussica"/>
 <contributor
+ name="Cyril Bouvier"
+ location="LIRMM, Montpellier, France"
+ work="Research Engineer, CNRS"
+ url="https://bouvier.lirmm.net/"
+ trac="bouvier"
+ github="cyrilbouvier"/>
+<contributor
  name="Florian Bouyer"
  trac="florian"/>
 <contributor


### PR DESCRIPTION
Add Cyril Bouvier in contributors.xml

And is it possible to reclaim my sagetrac mannequin 'bouvier' ? (it appear, for example in https://github.com/sagemath/sage/issues/29164)