### PR TITLE
Replace various outdated wiki links

### DIFF
--- a/scripts/mirror-index-template.xml
+++ b/scripts/mirror-index-template.xml
@@ -95,7 +95,7 @@ pageTracker._trackPageview();
       "https://www.sagemath.org">SageMath - Open Source Mathematics Software</a>.
       Here, you can download SageMath for your system and platform. Not sure what
       to download? Then follow the <a target="_blank" href=
-      "https://wiki.sagemath.org/DownloadAndInstallationGuide">
+      "https://doc.sagemath.org/html/en/installation/index.html">
       <strong>download guide</strong></a>. For more information, visit the
       <a href="https://www.sagemath.org/">SageMath website</a>.
     </div>

--- a/scripts/mirror-index.py
+++ b/scripts/mirror-index.py
@@ -281,7 +281,7 @@ def getTableHeader(xml):
        if i == 'Metalink':
          a = xml.createElement(u'a')
          a.appendChild(xml.createTextNode(i))
-         a.setAttribute(u'href', 'http://wiki.sagemath.org/DownloadAndInstallationGuide')
+         a.setAttribute(u'href', 'https://doc.sagemath.org/html/en/installation/index.html')
          td.appendChild(a)
        else:
          td.appendChild(xml.createTextNode(i))

--- a/scripts/mirror-meta.sh
+++ b/scripts/mirror-meta.sh
@@ -43,7 +43,7 @@ function metatorrent () {
     done 
     # write content
     echo "<h1>$2 for <a href='https://www.sagemath.org/'>SageMath</a></h1>" >> $OUTPUT
-    echo '<div><strong>Read more <a href="https://wiki.sagemath.org/DownloadAndInstallationGuide">in the Download Guide</a></strong></div>' >> $OUTPUT
+    echo '<div><strong>Read more <a href="https://doc.sagemath.org/html/en/installation/index.html">in the Download Guide</a></strong></div>' >> $OUTPUT
     echo '<div><table>' >> $OUTPUT
     for f in `eval $FINDCMD`; do
      f=${f:2}

--- a/src/changelogs/index.html
+++ b/src/changelogs/index.html
@@ -4,7 +4,7 @@
 {% block content %}
 <h1>{{ title }}</h1>
 
-<div class="bodypadding">See also: <a href="https://wiki.sagemath.org/ReleaseTours/">Sage Release Tours</a> (Sage Wiki)
+<div class="bodypadding">See also: <a href="https://github.com/sagemath/sage/releases">GitHub Releases</a>
 </div>
 
 <p>

--- a/src/development.html
+++ b/src/development.html
@@ -27,7 +27,7 @@
       <li><a href="{{ docroot }}/html/en/faq/faq-usage.html">FAQ about using {{ sage }}</a></li>
       <li><a href="{{ docroot }}/html/en/faq/faq-contribute.html">FAQ about contributing to {{ sage }}</a></li>
     </ul>
-    <li><a href="https://wiki.sagemath.org/ReleaseTours/">Release Tours</a>, <a href="./changelogs/">Changelogs</a></li>
+    <li><a href="https://github.com/sagemath/sage/releases">Release notes</a> (GitHub Releases)</li>
     <li><a href="https://vimeo.com/14044496">Video: Contributing to {{ sage }}</a> from <a href="https://vimeo.com/user1449175">William Stein</a> on <a href="http://vimeo.com">Vimeo</a>.
   [<a href="https://wiki.sagemath.org/daysindia25/schedule?action=AttachFile&do=view&target=stein-contrib.pdf">download presentation (pdf)</a>.
   {# <a href="http://sage.math.washington.edu/home/wstein/video/sagedays25/Contributing%20to%20Sage.m4v">download video (m4v)</a> #}

--- a/src/download-source.html
+++ b/src/download-source.html
@@ -33,7 +33,7 @@
   provides information on the installation prerequisites.
 
   <p>
-    See also <a href="https://wiki.sagemath.org/ReleaseTours/sage-{{version_src}}">Release Tour for version {{version_src}}</a> and the <a href="changelogs/sage-{{version_src}}.txt">changelog</a>.<br />
+    See also the <a href="https://github.com/sagemath/sage/releases/tag/{{version_src}}">Release Notes for version {{version_src}}</a>.
   <p>
     You can <a href="https://github.com/sagemath/sage/">browse the main Sage repository on GitHub</a>.
     The <a href="https://github.com/sagemath">SageMath organization on GitHub</a>

--- a/src/download.html
+++ b/src/download.html
@@ -42,7 +42,6 @@ from "mirrorselector.html" import mirrors %} {% block content %}
 
 <div class="narrow txt">
   Not sure what to download? Follow the <a href=
-  "https://wiki.sagemath.org/DownloadAndInstallationGuide"><strong>download and
-  install guide</strong></a>.
+  "https://doc.sagemath.org/html/en/installation/index.html"><strong>Installation Guide</strong></a>.
 </div>
 {# #} {% endblock %}

--- a/templates/mirror/index.html
+++ b/templates/mirror/index.html
@@ -80,8 +80,8 @@ tr.odd, tr.even {background: #f0f0fff;}
   "http://www.sagemath.org">{{ sage }} - Open Source Mathematics Software</a>. Here,
   you can download {{ sage }} for your system and platform. Not sure what to
   download? Then follow the <a target="_blank" href=
-  "http://wiki.sagemath.org/DownloadAndInstallationGuide">
-  <strong>download guide</strong></a>. For more information, visit the
+  "https://doc.sagemath.org/html/en/installation/index.html">
+  <strong>Installation Guide</strong></a>. For more information, visit the
   <a href="http://www.sagemath.org/">{{ sage }} website</a>.
  </div>
 

--- a/templates/mirror/metalinks.html
+++ b/templates/mirror/metalinks.html
@@ -287,9 +287,9 @@ the
 <a
 target="_blank"
 href=
-"http://wiki.sagemath.org/DownloadAndInstallationGuide">
-<strong>download
-guide</strong></a>.
+"https://doc.sagemath.org/html/en/installation/index.html">
+<strong>Installation
+Guide</strong></a>.
 For
 more
 information,
@@ -300,7 +300,7 @@ href="http://www.sagemath.org/">{{ sage }}
 website</a>.
 </div>
 <h1>Metalinks for <a href='http://www.sagemath.org/'>{{ sage }}</a></h1>
-<div><strong>Read more <a href="http://wiki.sagemath.org/DownloadAndInstallationGuide">in the Download Guide</a></strong></div>
+<div><strong>Read more <a href="https://doc.sagemath.org/html/en/installation/index.html">in the Download Guide</a></strong></div>
 <div><table>
 <tr><td>solaris</td><td>
 <a onClick="pageTracker._trackEvent(MirrorDL, solaris, sparc-solaris-toolchain-gcc-4.3.2.tar.gz.metalink, 1)"

--- a/templates/mirror/torrents.html
+++ b/templates/mirror/torrents.html
@@ -278,7 +278,7 @@ the
 <a
 target="_blank"
 href=
-"http://wiki.sagemath.org/DownloadAndInstallationGuide">
+"https://doc.sagemath.org/html/en/installation/index.html">
 <strong>download
 guide</strong></a>.
 For
@@ -291,7 +291,7 @@ href="http://www.sagemath.org/">{{ sage }}Math
 website</a>.
 </div>
 <h1>BitTorrents for <a href='http://www.sagemath.org/'>{{ sage }}Math</a></h1>
-<div><strong>Read more <a href="http://wiki.sagemath.org/DownloadAndInstallationGuide">in the Download Guide</a></strong></div>
+<div><strong>Read more <a href="https://doc.sagemath.org/html/en/installation/index.html">in the Download Guide</a></strong></div>
 <div><table>
 <tr><td>solaris</td><td>
 <a onClick="pageTracker._trackEvent(MirrorDL, solaris, sparc-solaris-toolchain-gcc-4.3.2.tar.gz.torrent, 1)"


### PR DESCRIPTION
Getting rid of http://wiki.sagemath.org/DownloadAndInstallationGuide
and https://wiki.sagemath.org/ReleaseTours
