### PR TITLE
Replace trac links

### DIFF
--- a/scripts/geocode.py
+++ b/scripts/geocode.py
@@ -49,7 +49,6 @@ ack = parse(join("..", "conf", "contributors.xml"))
 geocode_xml_outfn = join("..", "conf", "geocode.xml")
 devmap_tmpl = os.path.join("..", "templates", "devs.html")
 devlist = None
-tracSearch = "https://trac.sagemath.org/sage_trac/search?q="
 
 devmap = minidom.Document()
 

--- a/src/development-prize.html
+++ b/src/development-prize.html
@@ -35,7 +35,7 @@ for incredible amounts of development contributions to the core codebase, especi
 
 <div class="narrow">
 <b><a href="https://www.math.ucdavis.edu/~mkoeppe/">Matthias Köppe</a></b> (he/him), UC Davis, is awarded the 2015&ndash;2021 SageMath Prize 
-for incredible and consistent contributions to the core Sage library, especially the <a href="https://trac.sagemath.org/ticket/29705">modularization effort</a>, which has the potential to massively extend the sustainability and broad impact of the Sage Python codebase.
+for incredible and consistent contributions to the core Sage library, especially the <a href="https://github.com/sagemath/sage/issues/29705">modularization effort</a>, which has the potential to massively extend the sustainability and broad impact of the Sage Python codebase.
 </div>
 
 <h2 class="narrow">2015&ndash;2021 SageMath Prize: Thierry Monteil</h2>

--- a/src/development-search.html
+++ b/src/development-search.html
@@ -4,6 +4,10 @@
 {% block content %}
  <h1>Search Engine for Developers</h1><noscript>
 
+<div class="txt narrow">
+  See <a href="https://github.com/sagemath/sage">sagemath/sage</a> (GitHub).
+</div>
+
    <li>
     <form action="http://wiki.sagemath.org/"
           method="get">
@@ -19,15 +23,6 @@
            type="submit" /> <input type="hidden"
            name="action"
            value="fullsearch" />
-    </form>
-   </li>
-
-   <li>
-    <form action="http://trac.sagemath.org/sage_trac/search"
-          method="get">
-     Search in <a href="http://trac.sagemath.org/sage_trac/">{{ sage }} trac</a>: <input name="q"
-           type="text" />&#160;<input type="submit"
-           value="search" />
     </form>
    </li>
 

--- a/src/development-status.html
+++ b/src/development-status.html
@@ -5,31 +5,5 @@
  <h1 class="narrow">Status of Development</h1>
 
 <div class="txt narrow">
-  See <a href="https://trac.sagemath.org/wiki/WikiStart#Followingthepulseofdevelopment">Following the pulse of development</a>.
+  See <a href="https://github.com/sagemath/sage">sagemath/sage</a> (GitHub).
 </div>
-
-</div>
-
-<script type="text/javascript"
-      src="http://www.google.com/jsapi?key=ABQIAAAA9l-aWy6wHEH5peWCry_l4hQm4J-jBIjYt60ld8MMTn6uhPOgVhSg6NCleXrEpyNFs6aDpgXODBd72w">
-</script>
-<script src="http://www.google.com/uds/solutions/dynamicfeed/gfdynamicfeedcontrol.js"
-      type="text/javascript">
-</script>
-<script type="text/javascript">
-//<![CDATA[
- function initialize() {
- var feedtrc = [unescape("http://trac.sagemath.org/timeline?milestone=on&amp;ticket=on&amp;wiki=off&amp;max=50&amp;daysback=20&amp;format=rss")];
- var options = {
-  stacked : false,
-  horizontal : false,
-  title : "",
-  numResults : 50
- }
- new GFdynamicFeedControl(feedtrc, 'tracfeed', options);
- }
- google.load('feeds', '1');
- google.setOnLoadCallback(initialize);
- //]]>
-</script>
-{% endblock %}

--- a/src/download.html
+++ b/src/download.html
@@ -6,12 +6,6 @@ from "mirrorselector.html" import mirrors %} {% block content %}
 
 <div class="narrow xlarge txt bluebg round">
   <p>
-    General information about <strong><a href=
-    "https://trac.sagemath.org/wiki/Distribution">Distribution and packaging of
-    SageMath</a></strong>
-  </p>
-
-  <p>
     <strong>Note:</strong> <strong>Linux</strong> binaries have been
     discontinued. See the <a href=
     "https://doc.sagemath.org/html/en/installation/index.html">

--- a/src/res/devmap2.js
+++ b/src/res/devmap2.js
@@ -17,7 +17,6 @@ var map_max_width     = 800; // max width of map;
 var overlay_max_width = null; //this is the width of the overlay div to restrict too wide layouts
 var dx_base           = parseFloat("2"); // disturbance in degrees (=dy)
 var zoom_level        = 3;    //holds current zoom level, for jitter
-var tracSearch        = "http://trac.sagemath.org/sage_trac/search?q=";
 var markers = [];
 var points = [];
 var cld = null;
@@ -61,11 +60,6 @@ function jitterPoint(point, amount) {
     return ret;
 }
 
-// search url for contributions
-function getTracLink(trac) {
-   return "<a class='trac' href='" + tracSearch + trac + "'>search contributions</a>";
-}
-
 // this ends up inside the InfoWindow
 function getInfoText(dev,loc,work,descr,url,pix,trac) {
   var txt = "";
@@ -89,7 +83,6 @@ function getInfoText(dev,loc,work,descr,url,pix,trac) {
       descr = "<ul><li>" + descr + "</li></ul>";//always a list is prettier
       txt += "<div class='mdesc'>"+ descr+"</div>";
   }
-  txt += getTracLink(trac);
   txt += "</div>";
   return txt;
 }

--- a/src/sagebook/french.html
+++ b/src/sagebook/french.html
@@ -639,11 +639,11 @@ pr&eacute;liminaire.
 <div class="paragraph"><p>Vous pouvez contribuer &agrave; la p&eacute;rennit&eacute; des exemples de ce livre en faisant une
 <em>review</em> des fichiers de <em>doctest</em> correspondant aux
 chapitres du livre:
-<!--<a href="http://trac.sagemath.org/sage_trac/ticket/9395">Corps
+<!--<a href="https://github.com/sagemath/sage/issues/9395">Corps
 finis et th&eacute;orie des nombres</a> (fait),
 <a href="http://trac.sagemath.org/sage_trac/ticket/11672">Polyn&ocirc;mes et
 syst&egrave;mes polynomiaux</a>,!-->
-<a href="http://trac.sagemath.org/sage_trac/ticket/10983">Calculus et graphiques</a>.
+<a href="https://github.com/sagemath/sage/issues/10983">Calculus et graphiques</a>.
 </p></div>
 <div class="paragraph"><p>Merci d'envoyer tout commentaire (erreur ou autre)
 sur ce livre &agrave; Paul Zimmermann (<tt>Paul dot Zimmermann at inria dot fr</tt>).</p></div>

--- a/src/sagebook/french.html
+++ b/src/sagebook/french.html
@@ -641,7 +641,7 @@ pr&eacute;liminaire.
 chapitres du livre:
 <!--<a href="https://github.com/sagemath/sage/issues/9395">Corps
 finis et th&eacute;orie des nombres</a> (fait),
-<a href="http://trac.sagemath.org/sage_trac/ticket/11672">Polyn&ocirc;mes et
+<a href="https://github.com/sagemath/sage/issues/11672">Polyn&ocirc;mes et
 syst&egrave;mes polynomiaux</a>,!-->
 <a href="https://github.com/sagemath/sage/issues/10983">Calculus et graphiques</a>.
 </p></div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -168,7 +168,7 @@ or
 
 <li><a href="{{ 'links.html'|prefix }}">Links</a>
 <ul>
- <li><a href="https://github.com/sagemath/sage/wiki/WikiStart#surveying-the-mathematical-software-landscape" class="ext">Math Software Landscape</a></li>
+ <li><a href="https://github.com/sagemath/sage/wiki/Mathematical-Software-Landscape" class="ext">Math Software Landscape</a></li>
  <li><a href="https://doc.sagemath.org/html/en/reference/spkg/" class="ext">{{ sage }} Components</a></li>
  <li class="section"><a href="https://sagecell.sagemath.org/" class="ext">{{ sage }} Cell Server</a></li>
  <li><a href="https://wiki.sagemath.org/">{{ sage }} Wiki</a></li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -160,7 +160,6 @@ or
  <li><a href="https://github.com/sagemath/sage" class="ext">GitHub repository</a></li>
  <li><a href="{{ 'development-groups.html'|prefix }}">Mailing Lists</a></li>
  <li><a href="{{ 'development-map.html'|prefix }}">Developer Map</a></li>
- {# <li><a href="https://trac.sagemath.org/wiki/WikiStart#Followingthepulseofdevelopment" class="ext">Status</a></li> #}
  <li><a href="{{ 'development-prize.html'|prefix }}">Prize</a></li>
  <li><a href="{{ 'development-ack.html'|prefix }}">Acknowledgment</a></li>
  <li><a href="{{ docroot }}/html/en/developer/" class="ext">Developer Guide</a></li>


### PR DESCRIPTION
Note: After merging, we can remove https://github.com/sagemath/sage/wiki/WikiStart