### PR TITLE
Remove refs to Twitter

### DIFF
--- a/src/library-press.html
+++ b/src/library-press.html
@@ -168,7 +168,6 @@ For a personal report what has motivated Prof. Stein to build {{ sage }} read
 <div class="narrow txt">
 <ul>
 <li><a href="https://www.facebook.com/sagemathorg/">{{ sage }} Facebook group</a>,
-    <a href="https://twitter.com/sagemath">{{ sage }} Twitter page</a>.
     <a rel="me" href="https://mathstodon.xyz/@sagemath">{{ sage }} Mastodon page</a>
 <li><a href="./library-marketing.html">Marketing Material</a></li>
 <li><a href="./library-stories.html">Quotes, Testimonials and Stories about {{ sage }}</a></li>

--- a/src/res/sage.js
+++ b/src/res/sage.js
@@ -149,17 +149,6 @@ function initMathjax() {
   head.appendChild(script);
 }
 
-/* Twitter */
-function initTwitter(d,s,id){
-  var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';
-  if(!d.getElementById(id)){
-    js=d.createElement(s);
-    js.id=id;
-    js.src=p+'://platform.twitter.com/widgets.js';
-    fjs.parentNode.insertBefore(js,fjs);
-  }
-}
-
 /* facebook app */
 //function initFacebook(d, s, id) {
 //  var js, fjs = d.getElementsByTagName(s)[0];
@@ -211,6 +200,5 @@ $(sage.touchMenu);
 //$(sage.tracklinks);
 $(initHistats);
 $(initMathjax);
-$(function() { initTwitter(document, 'script', 'twitter-wjs');});
 //$(function() { initFacebook(document, 'script', 'facebook-jssdk');});
 $(initClustermap);

--- a/templates/base.html
+++ b/templates/base.html
@@ -73,8 +73,6 @@ or
 
 <a href="https://www.facebook.com/pages/Sage-Math/26593144945">
     <img alt="F" src="{{ 'pix/facebook-favicon.ico'|prefix }}" width="16" height="16" /></a>
-<a href="https://twitter.com/sagemath">
-    <img alt="T" src="{{ 'pix/twitter-favicon.ico'|prefix }}" width="16" height="16"/></a>
 <a href="https://mathstodon.xyz/@sagemath">
     <img alt="T" src="{{ 'pix/mastodon-favicon.ico'|prefix }}" width="16" height="16"/></a>
 {%- endblock -%}
@@ -234,9 +232,6 @@ or
 
 <td></td>
 
-<td>
-<a href="https://twitter.com/share" class="twitter-share-button" data-url="https://sagemath.org" data-text="I like @sagemath" data-related="sagemath">Tweet</a>
-</td>
 </tr>
 
 <tr>

--- a/templates/mirror/backup.html
+++ b/templates/mirror/backup.html
@@ -103,7 +103,6 @@ tr.odd, tr.even {background: #f0f0fff;}
 
   <li>Visit us in the sphere of social networks:</li>
    <ul>
-     <li><a href="https://twitter.com/sagemath">Twitter</a></li>
      <li><a href="https://mathstodon.xyz/@sagemath">Mastodon</a></li>
      <li><a href="https://www.facebook.com/pages/Sage-Math/26593144945">Facebook</a></li>
    </ul>


### PR DESCRIPTION
The subject says it all. Academic institutions are leaving the platform en masse, it's no longer possible to follow links there without an account, etc etc. 