### PR TITLE
Fix dead link for Interactive Worksheets in library.html

### DIFF
--- a/src/library.html
+++ b/src/library.html
@@ -42,7 +42,7 @@
      <li><a href="calctut/index.html">Calculus Tutorial</a> — explains Calculus in {{ sage }} by
      Elliott Brossard</li>
 
-     <li><a href="http://www.math.usm.edu/sage/">Interactive Worksheets for Calculus I &amp; II</a>
+     <li><a href="https://web.archive.org/web/20150910000000*/http://www.math.usm.edu/sage/">Interactive Worksheets for Calculus I &amp; II</a>
      — explaining Calc I &amp; II with slides using {{ sage }} by John Perry.</li>
     </ul>
    </li>


### PR DESCRIPTION
Description:
This PR addresses issue #492.

Changes:
Replaced the broken USM link (math.usm.edu/sage/) with a stable archive link from the Wayback Machine.

Verified that the archived link correctly points to the "Interactive Worksheets for Calculus I & II" by John Perry.

Fixes #492